### PR TITLE
manage TDS_DATA_COLUMNSTATUS in ValueReader

### DIFF
--- a/src/AdoNetCore.AseClient/Enum/TdsDataColumnStatus.cs
+++ b/src/AdoNetCore.AseClient/Enum/TdsDataColumnStatus.cs
@@ -1,0 +1,22 @@
+using System;
+// ReSharper disable InconsistentNaming
+
+namespace AdoNetCore.AseClient.Enum
+{
+    [Flags]
+    internal enum TdsDataColumnStatus : byte
+    {
+        /// <summary>
+        /// No Data follows, the value is NULL.
+        /// </summary>
+        TDS_DATA_COLUMNSTATUS_NO_DATA = 0x01,
+        /// <summary>
+        /// This data value is corrupted due to Overflow/Underflow.
+        /// </summary>
+        TDS_DATA_COLUMNSTATUS_CORRUPTED = 0x02,
+        /// <summary>
+        /// This data value has been truncated or rounded.
+        /// </summary>
+        TDS_DATA_COLUMNSTATUS_TRUNCATED = 0x04,
+    }
+}

--- a/src/AdoNetCore.AseClient/Internal/ValueReader.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueReader.cs
@@ -61,6 +61,15 @@ namespace AdoNetCore.AseClient.Internal
         {
             if (ReadMap.ContainsKey(format.DataType))
             {
+                // If the TDS_DATA_COLUMNSTATUS request capability is enabled, then all datatype representations begin with a status byte
+                if (format.RowStatus.HasFlag(RowFormatItemStatus.TDS_ROW_COLUMNSTATUS))
+                {
+                    var columnStatus = (TdsDataColumnStatus)stream.ReadByte();
+                    if (columnStatus.HasFlag(TdsDataColumnStatus.TDS_DATA_COLUMNSTATUS_NO_DATA))
+                    {
+                        return DBNull.Value;
+                    }
+                }
                 return ReadMap[format.DataType](stream, format, env) ?? DBNull.Value;
             }
 


### PR DESCRIPTION
This PR add a basic management for TDS_DATA_COLUMNSTATUS capability in ValueReader.

Context:
I discovered an issue connecting to a Sybase IQ database, trying to execute a select statement and read the results.
and after debugging, and reading TDS protocol specifications:
> if the TDS_DATA_COLUMNSTATUS request capability is enabled, then all datatype representations begin with a status byte.

the format token sent by server has TDS_ROW_COLUMNSTATUS flag in RowStatus for string fields,
not reading this status byte causes stream read errors.