### PR TITLE
Switch to correct dispose pattern + Prevent rollback when connection is Broken or closed

### DIFF
--- a/src/AdoNetCore.AseClient/AseTransaction.cs
+++ b/src/AdoNetCore.AseClient/AseTransaction.cs
@@ -165,7 +165,7 @@ namespace AdoNetCore.AseClient
                 throw new ObjectDisposedException(nameof(AseTransaction));
             }
 
-            if (_complete)
+            if (_complete || _connection.State == ConnectionState.Closed || _connection.State == ConnectionState.Broken)
             {
                 return;
             }

--- a/src/AdoNetCore.AseClient/AseTransaction.cs
+++ b/src/AdoNetCore.AseClient/AseTransaction.cs
@@ -141,16 +141,21 @@ namespace AdoNetCore.AseClient
         /// </summary>
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (_isDisposed)
             {
                 return;
             }
 
-            Rollback();
+            if (disposing)
+            {
+                _connection?.Dispose();
+            }
 
+            Rollback();
             _isDisposed = true;
+
+            base.Dispose(disposing);
+           
         }
 
         internal bool IsDisposed => _isDisposed;

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseTransactionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseTransactionTests.cs
@@ -273,8 +273,8 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var connection = mockConnection.Object;
             var transaction = connection.BeginTransaction(isolationLevel);
 
-
-            transaction.Dispose(); // Implicit rollback
+            Assert.DoesNotThrow(() => { transaction.Dispose(); });
+                 // Implicit rollback
         }
 
 
@@ -290,6 +290,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockCommandIsolationLevel = new Mock<IDbCommand>();
             var mockCommandBeginTransaction = new Mock<IDbCommand>();
             var mockCommandRollbackTransaction = new Mock<IDbCommand>();
+           
 
             mockCommandIsolationLevel
                 .SetupAllProperties()
@@ -305,6 +306,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
                 .SetupAllProperties()
                 .Setup(x => x.ExecuteNonQuery())
                 .Returns(0);
+
             mockConnection
                 .Setup(x => x.BeginTransaction(isolationLevel))
                 .Returns(() =>
@@ -328,6 +330,16 @@ namespace AdoNetCore.AseClient.Tests.Unit
 
             transaction.Dispose(); // Implicit rollback
             transaction.Dispose(); // Should do nothing
+            
+            mockConnection.Verify(t => t.Dispose(), Times.Once, "we called multiple time the dispose on the master");
+
+            //mockAseTransaction.Object.
+            //we tried to make this work but cannot work it as long as the class is sealed and it's sealed for performance constraint.
+            //if you want to verify it still, use  var mockAseTransaction = new Mock<AseTransaction>(MockBehavior.Loose,mockConnection.Object, isolationLevel) { CallBase = true }
+            //mockAseTransaction.Verify(t => t.Rollback(), Times.Once, "we should have only called once the rollback");
+
+
+
         }
     }
 }


### PR DESCRIPTION
1/ Switch to correct dispose pattern
2/ Prevent rollback when connection is Broken or closed.
Otherwise, Dispose called by the GC were throwing an exception when trying to rollback on a broken Connection
Resulting in a error thrown during GC and fatal on all DS

Co-authored-by: Paciv, floriangouzeext, Paul BARRY DELONGCHAMPS
